### PR TITLE
Go 1.11 refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ It exposes two HTTP endpoints:
 1. `GET /v1/indicator-documents` This returns the list of all currently registered indicator documents as a json array.
 
 ```
-vgo install code.cloudfoundry.org/cf-indicators/cmd/registry
+go install code.cloudfoundry.org/cf-indicators/cmd/registry
 registry --port 8080
 
 # POST an indicator document to the registry

--- a/ci/build-and-test/Dockerfile
+++ b/ci/build-and-test/Dockerfile
@@ -1,11 +1,7 @@
-FROM golang:1.10.3
+FROM golang:1.11
 
 ENV GOPATH=$PWD/go
 ENV PATH=$PATH:$GOPATH/bin
-
-RUN apt-get update
-RUN apt-get -y install clang jq
-RUN go get -u golang.org/x/vgo
 
 RUN wget -O cf.tgz "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=6.38.0&source=github-rel"
 RUN tar xzf cf.tgz cf

--- a/ci/pipelines/cf-indicators.yml
+++ b/ci/pipelines/cf-indicators.yml
@@ -32,7 +32,7 @@ jobs:
         type: docker-image
         source:
           repository: pcfmetrics/indicators-build-and-test
-          tag: latest
+          tag: go-1.11
       inputs:
       - name: cf-indicators
         path: go/src/code.cloudfoundry.org/cf-indicators
@@ -66,7 +66,7 @@ jobs:
         type: docker-image
         source:
           repository: pcfmetrics/indicators-build-and-test
-          tag: latest
+          tag: go-1.11
       inputs:
       - name: env-state
       - name: cf-indicators
@@ -177,7 +177,7 @@ jobs:
         type: docker-image
         source:
           repository: pcfmetrics/indicators-build-and-test
-          tag: latest
+          tag: go-1.11
       inputs:
       - name: cf-indicators
         path: go/src/code.cloudfoundry.org/cf-indicators

--- a/ci/pipelines/cf-indicators.yml
+++ b/ci/pipelines/cf-indicators.yml
@@ -46,7 +46,7 @@ jobs:
             set -exu
 
             pushd go/src/code.cloudfoundry.org/cf-indicators
-              vgo test ./...
+              go test ./... -v
             popd
 
 - name: push-to-acceptance
@@ -95,7 +95,7 @@ jobs:
 
             pushd go/src/code.cloudfoundry.org/cf-indicators
               mkdir cf-indicator-registry
-              vgo build -o cf-indicator-registry/registry code.cloudfoundry.org/cf-indicators/cmd/registry
+              go build -o cf-indicator-registry/registry code.cloudfoundry.org/cf-indicators/cmd/registry
 
               cf push -p cf-indicator-registry -b binary_buildpack --no-manifest indicator-registry -c './registry --port $PORT'
             popd
@@ -191,6 +191,6 @@ jobs:
             set -exu
 
             pushd go/src/code.cloudfoundry.org/cf-indicators
-              vgo install code.cloudfoundry.org/cf-indicators/cmd/generate_docs
+              go install code.cloudfoundry.org/cf-indicators/cmd/generate_docs
               generate_docs example.yml
             popd

--- a/cmd/generate_docs/main_test.go
+++ b/cmd/generate_docs/main_test.go
@@ -9,13 +9,13 @@ import (
 	"bytes"
 	"os"
 	"os/exec"
-	"code.cloudfoundry.org/cf-indicators/pkg/vgo_test"
+	"code.cloudfoundry.org/cf-indicators/pkg/go_test"
 )
 
 func TestGenerateDocsBinary(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	binPath, err := vgo_test.Build("./")
+	binPath, err := go_test.Build("./")
 	g.Expect(err).ToNot(HaveOccurred())
 
 	t.Run("accepts indicator yml file as a command line argument and returns formatted HTML", func(t *testing.T) {

--- a/cmd/registry/main_test.go
+++ b/cmd/registry/main_test.go
@@ -13,13 +13,13 @@ import (
 	"fmt"
 	"net"
 
-	"code.cloudfoundry.org/cf-indicators/pkg/vgo_test"
+	"code.cloudfoundry.org/cf-indicators/pkg/go_test"
 )
 
 func TestIndicatorRegistry(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	binPath, err := vgo_test.Build("./")
+	binPath, err := go_test.Build("./")
 	g.Expect(err).ToNot(HaveOccurred())
 
 	t.Run("it saves and exposes indicators with labels", func(t *testing.T) {

--- a/cmd/registry_agent/main_test.go
+++ b/cmd/registry_agent/main_test.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"code.cloudfoundry.org/cf-indicators/pkg/vgo_test"
+	"code.cloudfoundry.org/cf-indicators/pkg/go_test"
 	"github.com/onsi/gomega/ghttp"
 	"net/http"
 	"os"
@@ -17,7 +17,7 @@ import (
 func TestIndicatorRegistryAgent(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	binPath, err := vgo_test.Build("./")
+	binPath, err := go_test.Build("./")
 	g.Expect(err).ToNot(HaveOccurred())
 
 	t.Run("it sends indicator documents to the registry on an interval", func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestIndicatorRegistryAgent(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		defer session.Kill()
 
-		g.Expect((<- receivedDocuments).Product).To(Equal("job-a-product"))
-		g.Expect((<- receivedDocuments).Product).To(Equal("job-b-product"))
+		g.Expect((<-receivedDocuments).Product).To(Equal("job-a-product"))
+		g.Expect((<-receivedDocuments).Product).To(Equal("job-b-product"))
 	})
 }

--- a/cmd/uaa_scoped_proxy/main_test.go
+++ b/cmd/uaa_scoped_proxy/main_test.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"os"
 	"net/http"
-	"code.cloudfoundry.org/cf-indicators/pkg/vgo_test"
+	"code.cloudfoundry.org/cf-indicators/pkg/go_test"
 	"io/ioutil"
 	"github.com/onsi/gomega/ghttp"
 	"net/url"
@@ -19,7 +19,7 @@ import (
 func TestUaaScopedProxy(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	binPath, err := vgo_test.Build("./")
+	binPath, err := go_test.Build("./")
 	g.Expect(err).ToNot(HaveOccurred())
 
 	t.Run("passes authorized requests to the backend server", func(t *testing.T) {

--- a/cmd/validate/main_test.go
+++ b/cmd/validate/main_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	"time"
 	"fmt"
-	"code.cloudfoundry.org/cf-indicators/pkg/vgo_test"
+	"code.cloudfoundry.org/cf-indicators/pkg/go_test"
 )
 
 func TestValidateIndicators(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	binPath, err := vgo_test.Build("./")
+	binPath, err := go_test.Build("./")
 	g.Expect(err).ToNot(HaveOccurred())
 
 	t.Run("returns 0 when all metrics are found over 1m", func(t *testing.T) {

--- a/pkg/go_test/build.go
+++ b/pkg/go_test/build.go
@@ -1,4 +1,4 @@
-package vgo_test
+package go_test
 
 import (
 	"os/exec"
@@ -12,7 +12,7 @@ func Build(packagePath string, args ...string) (compiledPath string, err error) 
 		return "", err
 	}
 
-	build := exec.Command("vgo", "build", "-o", tmpDir + "/build", packagePath)
+	build := exec.Command("go", "build", "-o", tmpDir + "/build", packagePath)
 
 	output, err := build.CombinedOutput()
 	if err != nil {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 go clean -cache
-vgo test ./... -v
+go test ./... -v
 
 exit_status=$?
 


### PR DESCRIPTION
removes the dependency on vgo, instead using Go 1.11 modules for all package vendoring.